### PR TITLE
Fix build error due to breaking change in crossterm 0.27.0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crossterm::{cursor, QueueableCommand, Result};
+use crossterm::{cursor, QueueableCommand};
 use rand::Rng;
 use std::cmp::{max, min};
 use std::io::Write;
@@ -6,6 +6,7 @@ use std::io::Write;
 type Vec3 = nalgebra::Vector3<f32>;
 type Point = nalgebra::Point3<f32>;
 type Mat4 = nalgebra::Matrix4<f32>;
+pub type Result<T> = std::result::Result<T, std::io::Error>;
 
 fn relu(x: f32) -> f32 {
     if x >= 0.0 {
@@ -189,6 +190,6 @@ fn main() -> Result<()> {
         stdout.queue(crossterm::style::Print("F O R B I D D E N D O N U T"))?;
 
         stdout.flush()?;
-        std::thread::sleep_ms(50);
+        std::thread::sleep(std::time::Duration::from_millis(50));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 type Vec3 = nalgebra::Vector3<f32>;
 type Point = nalgebra::Point3<f32>;
 type Mat4 = nalgebra::Matrix4<f32>;
-pub type Result<T> = std::result::Result<T, std::io::Error>;
+type Result<T> = std::result::Result<T, std::io::Error>;
 
 fn relu(x: f32) -> f32 {
     if x >= 0.0 {


### PR DESCRIPTION
I wanted to try your donut animation, but noticed that it wouldn't build. I saw that `crossterm` in 0.27.0 removed its `Result` type. So I added an equivalent type alias so it would build for the latest version. An alternative would be to pin `crossterm` to 0.26.1.

A small fix to use `std::thread::sleep` instead of `std::thread::sleep_ms`. 